### PR TITLE
Remove Google+ links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -79,8 +79,8 @@ google_plus_one_size: medium
 
 # Google Plus Profile
 # Hidden: No visible button, just add author information to search results
-googleplus_user: +xoreosorgxoreos
-googleplus_hidden: false
+googleplus_user:
+googleplus_hidden: true
 
 # Pinboard
 pinboard_user:

--- a/source/_includes/custom/footer.html
+++ b/source/_includes/custom/footer.html
@@ -1,6 +1,6 @@
 <div style="display:inline">
 <p>xoreos is developed by the <a href="https://github.com/xoreos/xoreos/blob/master/AUTHORS">xoreos Team</a>.</p>
 <p>This site and the xoreos project itself are not operated by, sponsored by, endorsed by, or affiliated with BioWare, Electronic Arts or any of their subsidiaries or partners.</p>
-<p><a href="https://wiki.xoreos.org/index.php?title=Contact_us">Contact us</a> • <a href="https://plus.google.com/106319254924552006586" rel="publisher">Google+</a> • <a href="https://twitter.com/xoreosorg">Twitter</a></p>
+<p><a href="https://wiki.xoreos.org/index.php?title=Contact_us">Contact us</a> • <a href="https://twitter.com/xoreosorg">Twitter</a></p>
 Powered by <a href="http://octopress.org">Octopress</a> | Theme <a href="http://github.com/panks/fabric">fabric</a> by <a href="http://panks.me">Pankaj Kumar</a>
 </div>


### PR DESCRIPTION
Google+ is long dead for customers and brand accounts and as such [the links are dead](https://plus.google.com/106319254924552006586). Let's remove them.